### PR TITLE
* Use common (explicitly assigned) manifest name instead of inferrred…

### DIFF
--- a/lib/EntryDownloader.js
+++ b/lib/EntryDownloader.js
@@ -2,24 +2,21 @@
  * Created by AsherS on 8/24/15.
  */
 
-var _ = require('underscore');
-var path = require('path');
-var url = require('url');
-var logger = require('./logger/logger');
-var flavorDownloader = require('./flavor-downloader');
-var masterManifestGeneratorCreator = require('./MasterManifestGenerator');
-var persistenceFormat = require('./PersistenceFormat');
-var config = require('./Configuration');
-var qio = require('q-io/fs');
 
 var EntryDownloader = (function () {
-    function EntryDownloader(entryId) {
+
+    var _ = require('underscore');
+    var path = require('path');
+    var logger = require('./logger/logger');
+    var flavorDownloader = require('./FlavorDownloader');
+    var masterManifestGeneratorCreator = require('./MasterManifestGenerator');
+    var persistenceFormat = require('./PersistenceFormat');
+    var Q = require('Q');
+
+
+    function EntryDownloader(entryId, hostname, port, applicationName) {
         this.entryId = entryId;
         this.flavorsDownloaders = [];
-
-        var hostname = config.get('mediaServer').hostname;
-        var port = config.get('mediaServer').port;
-        var applicationName = config.get('mediaServer').applicationName;
         this.masterManifestGenerator = masterManifestGeneratorCreator(entryId, hostname, port, applicationName);
     }
 
@@ -44,12 +41,29 @@ var EntryDownloader = (function () {
                     return f.start();
                 });
 
-                return Q.all(promises);
+                return Q.allSettled(promises);
 
-            }).then(function () {
-                logger.info("Successfully started all flavor downloaders for EntryId: " + that.entryId);
-            }).catch(function(err) {
-                throw new Error("Failed to start entry downloader for entry: " + that.entryId + "\n" + err);
+            }).then(function (results) {
+                var failedFlavors = _.filter(results, function (result) {
+                    return result.state === "rejected";
+                });
+
+                if (failedFlavors.length === results.length) {
+                    throw new Error("Failed to start entry downloader for entry: " + that.entryId + ". All flavor downloaders failed");
+                }
+
+                var successfullFlavors = _.filter(results, function(result){
+                    return result.state === "fulfilled";
+                })
+
+                if (failedFlavors.length > 0)
+                {
+                    var message = 'Could not start the following flavors for entry id: ' + this.entryId + '\n';
+                    message += _.map(failedFlavors, function(err){
+                       return err.flavor;
+                    }).toString();
+                    logger.warn(message);
+                }
             });
     };
 

--- a/lib/EntryDownloader.js
+++ b/lib/EntryDownloader.js
@@ -51,7 +51,7 @@ var EntryDownloader = (function () {
 
                 var successfullFlavors = _.filter(results, function(result){
                     return result.state === "fulfilled";
-                })
+                });
 
                 if (failedFlavors.length > 0)
                 {

--- a/lib/EntryDownloader.js
+++ b/lib/EntryDownloader.js
@@ -2,18 +2,15 @@
  * Created by AsherS on 8/24/15.
  */
 
+var _ = require('underscore');
+var path = require('path');
+var logger = require('./logger/logger');
+var flavorDownloader = require('./FlavorDownloader');
+var masterManifestGeneratorCreator = require('./MasterManifestGenerator');
+var persistenceFormat = require('./PersistenceFormat');
+var Q = require('Q');
 
 var EntryDownloader = (function () {
-
-    var _ = require('underscore');
-    var path = require('path');
-    var logger = require('./logger/logger');
-    var flavorDownloader = require('./FlavorDownloader');
-    var masterManifestGeneratorCreator = require('./MasterManifestGenerator');
-    var persistenceFormat = require('./PersistenceFormat');
-    var Q = require('Q');
-
-
     function EntryDownloader(entryId, hostname, port, applicationName) {
         this.entryId = entryId;
         this.flavorsDownloaders = [];

--- a/lib/FlavorDownloader.js
+++ b/lib/FlavorDownloader.js
@@ -2,21 +2,20 @@
  * Created by AsherS on 8/20/15.
  */
 
+var Q = require('q');
+var _ = require('underscore');
+var path = require('path');
+var url = require('url');
+var httpUtils = require('./utils/http-utils');
+var qfs = require("q-io/fs");
+var logger = require('./logger/logger');
+var config = require('./Configuration');
+var m3u8Handler = require('./promise-m3u8');
+var chunklistM3u8Generator = require('./ChunklistManifestGenerator');
+var util = require("util");
+var events = require("events");
 
 var FlavorDownloader = (function () {
-
-    var Q = require('q');
-    var _ = require('underscore');
-    var path = require('path');
-    var url = require('url');
-    var httpUtils = require('./utils/http-utils');
-    var qfs = require("q-io/fs");
-    var logger = require('./logger/logger');
-    var config = require('./Configuration');
-    var m3u8Handler = require('./promise-m3u8');
-    var chunklistM3u8Generator = require('./ChunklistManifestGenerator');
-    var util = require("util");
-    var events = require("events");
 
     function FlavorDownloader(m3u8Url, destPath, entryId, flavor, newPlaylistName) {
         events.EventEmitter.call(this);

--- a/lib/FlavorDownloader.js
+++ b/lib/FlavorDownloader.js
@@ -2,20 +2,21 @@
  * Created by AsherS on 8/20/15.
  */
 
-var Q = require('q');
-var _ = require('underscore');
-var path = require('path');
-var url = require('url');
-var httpUtils = require('./utils/http-utils');
-var qfs = require("q-io/fs");
-var logger = require('./logger/logger');
-var config = require('./Configuration');
-var m3u8Handler = require('./promise-m3u8');
-var chunklistM3u8Generator = require('./ChunklistManifestGenerator');
-var util = require("util");
-var events = require("events");
 
 var FlavorDownloader = (function () {
+
+    var Q = require('q');
+    var _ = require('underscore');
+    var path = require('path');
+    var url = require('url');
+    var httpUtils = require('./utils/http-utils');
+    var qfs = require("q-io/fs");
+    var logger = require('./logger/logger');
+    var config = require('./Configuration');
+    var m3u8Handler = require('./promise-m3u8');
+    var chunklistM3u8Generator = require('./ChunklistManifestGenerator');
+    var util = require("util");
+    var events = require("events");
 
     function FlavorDownloader(m3u8Url, destPath, entryId, flavor, newPlaylistName) {
         events.EventEmitter.call(this);
@@ -152,7 +153,7 @@ var FlavorDownloader = (function () {
         logger.info(formatLogMsg(that,"Polling interval: " + this.pollingInterval));
 
         //create tmp destination folder for media-server m3u8 files
-        qfs.makeTree(this.tmpM3u8Folder)
+        return qfs.makeTree(this.tmpM3u8Folder)
             .then(function() {
                 return that.m3u8generator.init();
             })
@@ -161,6 +162,7 @@ var FlavorDownloader = (function () {
             })
             .catch(function(err){
                 logger.error("Error occurred while starting flavor downloader for entry id: " + that.entryId + " flavor: " + that.flavor + "\n" + err);
+                err.flavor = flavor;
                 throw err;
             });
     };

--- a/lib/FlavorDownloader.js
+++ b/lib/FlavorDownloader.js
@@ -94,29 +94,33 @@ var FlavorDownloader = (function () {
             });
     };
 
-
     var downloadPlaylist = function (that) {
 
+        logger.debug(formatLogMsg(that, "Downloading from : " + that.streamUrl));
         var parsedUrl = url.parse(that.streamUrl);
         var baseUrl = parsedUrl.href.substring(0, parsedUrl.href.lastIndexOf('/'));
         var playlistName = path.basename(parsedUrl.pathname);
         var playlistDestPath = path.join(that.tmpM3u8Folder, playlistName);
+        logger.debug(formatLogMsg(that, "Temp playlist folder located at: " + playlistDestPath));
 
         var downloadedM3u8;
 
+        logger.debug(formatLogMsg(that, "Downloading playlist content to : " + playlistDestPath));
         return httpUtils.downloadFile(that.streamUrl, playlistDestPath)
 
             .then(function finishedDownload() {
+                logger.debug(formatLogMsg(that, "Reading current M3U8 from " + playlistDestPath));
                 return m3u8Handler.parseM3U8(playlistDestPath);
             })
 
             .then(function listFilesInDest(m3u) {
-                logger.debug(formatLogMsg(that,"Received M3U8: " + m3u.toString()));
+                logger.debug(formatLogMsg(that,"Received M3U8: \n" + m3u.toString()));
                 downloadedM3u8 = m3u;
                 return qfs.list(that.destFolderPath);
             })
 
             .then(function downloadMissingChunks(files) {
+                logger.debug(formatLogMsg(that, "Missing files for flavor" + that.flavor + " are: " + files.toString()));
                 //get all files that are in playlist but not in dir
                 var chunksToDownload =  _.chain(downloadedM3u8.items.PlaylistItem)
 

--- a/lib/MasterManifestGenerator.js
+++ b/lib/MasterManifestGenerator.js
@@ -16,7 +16,6 @@ module.exports = function(entryId, hostname, port, applicationName) {
     /* jshint shadow:true */
     var persistenceFormat = require('./PersistenceFormat');
     var hostname = hostname || 'localhost';
-    var port = port || 1935;
     var applicationName = applicationName || 'kLive';
 
     // Examples:

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -10,6 +10,11 @@ var worker = createWorker();
 module.exports = worker;
 
 function createWorker(){
+
+    var hostname = config.get('mediaServer').hostname;
+    var port = config.get('mediaServer').port;
+    var applicationName = config.get('mediaServer').applicationName;
+
     var handledEntries = {};
     var pollingInterval = config.get('backendPollingInterval');
 

--- a/lib/entry-downloader.js
+++ b/lib/entry-downloader.js
@@ -13,7 +13,6 @@ var config = require('./Configuration');
 var qio = require('q-io/fs');
 
 var EntryDownloader = (function () {
-
     function EntryDownloader(entryId) {
         this.entryId = entryId;
         this.flavorsDownloaders = [];
@@ -25,16 +24,13 @@ var EntryDownloader = (function () {
     }
 
     EntryDownloader.prototype.start = function () {
-
         var that = this;
         logger.info("Starting entry downloader for entryId: " + that.entryId);
-        that.masterManifestGenerator.getAllFlavors()
+        return that.masterManifestGenerator.getAllFlavors()
             .then(function (flavors) {
                 that.flavorsDownloaders = _.map(flavors, function (flavor) {
 
-                    var parsedUrl = url.parse(flavor.liveURL);
-                    var playlistName = path.basename(parsedUrl.pathname);
-
+                    var playlistName = persistenceFormat.getManifestName();
                     var bitrate = flavor.bandwidth;
                     var destPath = persistenceFormat.getFlavorFullPath(that.entryId, bitrate);
 
@@ -43,11 +39,15 @@ var EntryDownloader = (function () {
                 });
 
                 //start the download
-                _.forEach(that.flavorsDownloaders, function (f) {
+                var promises = _.map(that.flavorsDownloaders, function (f) {
                     logger.info("EntryId: " + that.entryId + " - starting flavor downloader: " + f.flavor);
-                    f.start();  //TODO verify success with on-started event?
+                    return f.start();
                 });
 
+                return Q.all(promises);
+
+            }).then(function () {
+                logger.info("Successfully started all flavor downloaders for EntryId: " + that.entryId);
             }).catch(function(err) {
                 throw new Error("Failed to start entry downloader for entry: " + that.entryId + "\n" + err);
             });
@@ -56,13 +56,15 @@ var EntryDownloader = (function () {
     EntryDownloader.prototype.stop = function () {
         logger.info('stopping entry downloader for entry id: ' + this.entryId);
         var that = this;
-        _.forEach(this.flavorsDownloaders, function (downloader) {
-            try {
-                downloader.stop();
-            }
-            catch(err){
-                logger.error('failed stopping flavor downloader for entry id: ' + that.entryId + ' and flavor ' + downloader.flavor + "\n" + err);
-            }
+        var stopPromises =_.map(this.flavorsDownloaders, function (downloader) {
+                return downloader.stop();
+        });
+
+        return Q.all(stopPromises).then(function(){
+            logger.info('successfully stopped entry downloader for entry id: ' + that.entryId);
+        }, function(err){
+            logger.error('failed stopping flavor downloader for entry id: ' + that.entryId + ' and flavor ' + downloader.flavor + "\n" + err);
+            throw err;
         });
     };
 

--- a/lib/flavor-downloader.js
+++ b/lib/flavor-downloader.js
@@ -30,7 +30,6 @@ var FlavorDownloader = (function () {
     }
     util.inherits(FlavorDownloader, events.EventEmitter);
 
-
     var formatLogMsg = function (that, msg) {
         return "entryId: " + that.entryId + " , flavor: " + that.flavor + " - " + msg;
     };
@@ -162,13 +161,14 @@ var FlavorDownloader = (function () {
             })
             .catch(function(err){
                 logger.error("Error occurred while starting flavor downloader for entry id: " + that.entryId + " flavor: " + that.flavor + "\n" + err);
-                //TODO throw error?
+                throw err;
             });
     };
 
     FlavorDownloader.prototype.stop = function () {
         logger.info('stopping flavor downloader for entry id: ' + this.entryId + " flavor: " + this.flavor);
         this.shouldRun = false;
+        return Q.resolve();
     };
 
     return FlavorDownloader;

--- a/lib/logger/logger.js
+++ b/lib/logger/logger.js
@@ -6,6 +6,16 @@ var winston = require('winston');
 var config = require('../Configuration');
 
 winston.emitErrs = true;
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+
+var logPath = config.get('logFileName');
+var logFullPath = path.resolve('.', logPath);
+if (!fs.exists(logFullPath))
+{
+    mkdirp.sync(path.dirname(logFullPath));
+}
 
 var logger = new winston.Logger({
     transports: [

--- a/lib/promise-m3u8.js
+++ b/lib/promise-m3u8.js
@@ -39,7 +39,7 @@ module.exports.parseM3U8 = function(manifestStringOrStream, options){
             else
             {
                 // Value is the M3U8 path
-                stream = fs.createReadStream(manifestStringOrStream);
+                var stream = fs.createReadStream(manifestStringOrStream);
 
                 // This will wait until we know the readable stream is actually valid before piping
                 stream.on('readable', function () {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "underscore": "1.8.3",
     "request": "^2.61.0",
     "winston": "^1.0.1",
-    "nconf" : "0.7.2"
+    "nconf" : "0.7.2",
+    "mkdirp" : "0.5.1"
   }
 }

--- a/tests/EntryDownloader-spec.js
+++ b/tests/EntryDownloader-spec.js
@@ -1,0 +1,121 @@
+/**
+ * Created by elad.benedict on 8/30/2015.
+ */
+
+var proxyquire = require('proxyquire');
+var fs = require('fs');
+var chai = require('chai');
+var expect = chai.expect;
+var path = require('path');
+var sinon = require('sinon');
+var Q = require('Q');
+
+describe('Entry downloader spec', function() {
+
+    var createEntryDownloader = function (customizeMocks) {
+
+        var loggerMock = {
+            info : sinon.stub(),
+            error : sinon.stub(),
+            debug : sinon.stub()
+        };
+
+        flavorDownloaderMock = {
+            stop : sinon.stub().returns(Q.resolve()),
+            start : sinon.stub().returns(Q.resolve())
+        };
+        var flavorDownloaderCtorMock = sinon.stub().returns(flavorDownloaderMock);
+
+
+        masterManifestGeneratorMock = {
+            getAllFlavors : sinon.stub().returns(Q([
+                {
+                    bandwidth : 400000,
+                    liveURL : 'http://someLiveURL/1',
+                    entryId : 'entry1'
+                },
+                {
+                    bandwidth : 600000,
+                    liveURL : 'http://someLiveURL/2',
+                    entryId : 'entry2'
+                },
+                {
+                    bandwidth : 900000,
+                    liveURL : 'http://someLiveURL/2',
+                    entryId : 'entry2'
+                }
+            ]))
+        };
+
+        var masterManifestGeneratorCreatorMock = sinon.stub().returns(masterManifestGeneratorMock)
+
+        var mocks = {
+            './logger/logger' : loggerMock,
+            './FlavorDownloader' : flavorDownloaderCtorMock,
+            './MasterManifestGenerator' : masterManifestGeneratorCreatorMock
+        };
+
+        if (customizeMocks) {
+            customizeMocks(mocks);
+        }
+
+        var entryDownloaderCtor = proxyquire('../lib/EntryDownloader', mocks);
+        return new entryDownloaderCtor('12345', 'host', 8888, 'appName');
+    };
+
+    it('should succeed starting if all downloaders and manifest generator succeed starting', function (done) {
+
+        var entryDownloader = createEntryDownloader();
+        entryDownloader.start().then(function(){
+            done();
+        }).done(null, function(err){
+            done(err);
+        });
+    });
+
+    it('should fail starting if manifest generator fails to start', function (done) {
+
+        var injectMock = function(){
+            masterManifestGeneratorMock.getAllFlavors = sinon.stub().returns(Q.reject());
+        }
+
+        var entryDownloader = createEntryDownloader(injectMock);
+        entryDownloader.start().then(function(){
+            done(new Error('Start should fail'));
+        }, function (err){
+            done()
+        })
+    });
+
+    it('should fail starting if all of the downloaders fail to start', function (done) {
+
+        var injectMock = function(){
+            flavorDownloaderMock.start.returns(Q.reject());
+        }
+
+        var entryDownloader = createEntryDownloader(injectMock);
+        entryDownloader.start().then(function(){
+            expect(flavorDownloaderMock.start.callCount).to.equal(3);
+            done(new Error('Start should fail'));
+        }).done(null, function(err){
+            done();
+        })
+    });
+
+    it('should succeed starting if one of the downloader fails to start', function (done) {
+
+        var injectMock = function(){
+            flavorDownloaderMock.start.onSecondCall().returns(Q.reject());
+        }
+
+        var entryDownloader = createEntryDownloader(injectMock);
+        entryDownloader.start().then(function(){
+            expect(flavorDownloaderMock.start.callCount).to.equal(3);
+            done();
+        }).done(null, function(err){
+            done(err);
+        });
+    });
+
+});
+

--- a/tests/EntryDownloader-spec.js
+++ b/tests/EntryDownloader-spec.js
@@ -12,6 +12,8 @@ var Q = require('Q');
 
 describe('Entry downloader spec', function() {
 
+    var flavorDownloaderMock;
+
     var createEntryDownloader = function (customizeMocks) {
 
         var loggerMock = {
@@ -48,7 +50,7 @@ describe('Entry downloader spec', function() {
             ]))
         };
 
-        var masterManifestGeneratorCreatorMock = sinon.stub().returns(masterManifestGeneratorMock)
+        var masterManifestGeneratorCreatorMock = sinon.stub().returns(masterManifestGeneratorMock);
 
         var mocks = {
             './logger/logger' : loggerMock,
@@ -78,36 +80,36 @@ describe('Entry downloader spec', function() {
 
         var injectMock = function(){
             masterManifestGeneratorMock.getAllFlavors = sinon.stub().returns(Q.reject());
-        }
+        };
 
         var entryDownloader = createEntryDownloader(injectMock);
         entryDownloader.start().then(function(){
             done(new Error('Start should fail'));
         }, function (err){
-            done()
-        })
+            done();
+        });
     });
 
     it('should fail starting if all of the downloaders fail to start', function (done) {
 
-        var injectMock = function(){
+        var injectMock = function(mocks){
             flavorDownloaderMock.start.returns(Q.reject());
-        }
+        };
 
         var entryDownloader = createEntryDownloader(injectMock);
         entryDownloader.start().then(function(){
-            expect(flavorDownloaderMock.start.callCount).to.equal(3);
             done(new Error('Start should fail'));
         }).done(null, function(err){
+            expect(flavorDownloaderMock.start.callCount).to.equal(3);
             done();
-        })
+        });
     });
 
     it('should succeed starting if one of the downloader fails to start', function (done) {
 
         var injectMock = function(){
             flavorDownloaderMock.start.onSecondCall().returns(Q.reject());
-        }
+        };
 
         var entryDownloader = createEntryDownloader(injectMock);
         entryDownloader.start().then(function(){
@@ -118,5 +120,17 @@ describe('Entry downloader spec', function() {
         });
     });
 
+    it('should succeed stopping if all the downloaders succeed to stop', function (done) {
+
+        var entryDownloader = createEntryDownloader();
+        entryDownloader.start().then(function(){
+            entryDownloader.stop();
+        }).then(function(){
+            expect(flavorDownloaderMock.stop.callCount).to.equal(3);
+            done();
+        }).done(null, function(err){
+            done(err);
+        });
+    });
 });
 

--- a/tests/EntryDownloader-spec.js
+++ b/tests/EntryDownloader-spec.js
@@ -17,7 +17,8 @@ describe('Entry downloader spec', function() {
         var loggerMock = {
             info : sinon.stub(),
             error : sinon.stub(),
-            debug : sinon.stub()
+            debug : sinon.stub(),
+            warn : sinon.stub(),
         };
 
         flavorDownloaderMock = {

--- a/tests/MasterManifestGenerator-spec.js
+++ b/tests/MasterManifestGenerator-spec.js
@@ -36,7 +36,7 @@ describe('MasterManifestGenerator spec', function() {
         });
     });
 
-    it('should use port 1935 if port is not supplied', function(done){
+    it('should not use any port if port is not supplied', function(done){
         var mocks;
         var customizeMocksFunction = function(m){
             mocks = m;
@@ -47,7 +47,7 @@ describe('MasterManifestGenerator spec', function() {
         var masterManifestCreator = createMasterManifestGenerator(customizeMocksFunction, customizeCtorParamsFunction);
 
         masterManifestCreator.getManifest('http://someRequestedPath', 'mbr').done(function() {
-            expect(mocks['./NetworkClientFactory'].getNetworkClient().read.firstCall.args[0]).to.eql("http://localhost:1935/test/smil:12345_mbr.smil/playlist.m3u8");
+            expect(mocks['./NetworkClientFactory'].getNetworkClient().read.firstCall.args[0]).to.eql("http://localhost/test/smil:12345_mbr.smil/playlist.m3u8");
             done();
         });
     });

--- a/tests/flavor-downloader-spec.js
+++ b/tests/flavor-downloader-spec.js
@@ -53,49 +53,51 @@ describe('flavor-downloader tests', function() {
             init: sinon.stub().returns(Q.resolve()),
             update: sinon.stub().returns(func())
         };
+
         return sinon.stub().returns(m3u8Mock);
     }
 
-    function getFlavorDownloader(updateMocks)
-    {
+    function getFlavorDownloader(updateMocks) {
         var mockObjects = {};
         mockObjects['./utils/http-utils'] = generateHttpUtilsMock();
         mockObjects['q-io/fs'] = generateQioMock([]);
         mockObjects['./ChunklistManifestGenerator'] = generateChunklistM3umGeneratorMock();
         mockObjects['./promise-m3u8'] = generatePromiseM3u8Mock(path.join(__dirname, '/resources/flavor-downloader-data/simpleManifest.m3u8'));
         mockObjects['./logger/logger'] = {
-            info : sinon.stub(),
-            error : sinon.stub(),
-            debug : sinon.stub()
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub(),
+            debug: sinon.stub()
         };
 
-        if (updateMocks){
+        if (updateMocks) {
             updateMocks(mockObjects);
         }
 
         mocks = mockObjects;
 
-        var flavorDownloaderCtor = proxyquire('../lib/flavor-downloader', mockObjects);
+        var flavorDownloaderCtor = proxyquire('../lib/FlavorDownloader', mockObjects);
         var flavorDownloader = new flavorDownloaderCtor('m3u8Url', 'destPath', 'entryId', 'flavor', 'newPlaylistName');
         return flavorDownloader;
     }
 
-    it('should download all files successfully', function (done) {
+    it.skip('should download all files successfully', function (done) {
         var flavorDownloader = getFlavorDownloader();
-        flavorDownloader.start();
-        flavorDownloader.on("iteration-end", function () {
+        flavorDownloader.on("iteration-end", function() {
             try {
                 expect(mocks['./utils/http-utils'].downloadFile.callCount).to.eql(6);
                 done();
-            } catch(e) {
-                done(e);
+            }
+            catch (err) {
+                done(err);
             }
         });
+        flavorDownloader.start();
     });
 
-    it('should try to download failed ts again', function (done) {
+    it.skip('should try to download failed ts again', function (done) {
         var listOfFiles = ['media-uefvqmelj_b1017600_11.ts', 'media-uefvqmelj_b1017600_12.ts', 'media-uefvqmelj_b1017600_13.ts', 'media-uefvqmelj_b1017600_15.ts'];
-        var flavorDwonloader = getFlavorDownloader(function(mocks){
+        var flavorDwonloader = getFlavorDownloader(function (mocks) {
             mocks['q-io/fs'] = generateQioMock(listOfFiles);
         });
 
@@ -104,13 +106,13 @@ describe('flavor-downloader tests', function() {
             try {
                 expect(mocks['./utils/http-utils'].downloadFile.callCount).to.eql(2);
                 done();
-            } catch(e) {
+            } catch (e) {
                 done(e);
             }
         });
     });
 
-    it('should shutdown downloader after 1 iteration', function (done) {
+    it.skip('should shutdown downloader after 1 iteration', function (done) {
         var flavorDownloader = getFlavorDownloader();
         flavorDownloader.start();
         var iterationEndStub = sinon.stub();
@@ -123,14 +125,14 @@ describe('flavor-downloader tests', function() {
             try {
                 expect(iterationEndStub.callCount).to.eql(1);
                 done();
-            } catch(e) {
+            } catch (e) {
                 done(e);
             }
         });
     });
 
     it('should recover after failed manifest download', function (done) {
-        var flavorDwonloader = getFlavorDownloader(function(mocks){
+        var flavorDwonloader = getFlavorDownloader(function (mocks) {
             mocks['./utils/http-utils'] = generateHttpUtilsMock(true);
         });
 
@@ -146,7 +148,7 @@ describe('flavor-downloader tests', function() {
                 expect(mocks['./utils/http-utils'].downloadFile.callCount).to.eql(2);
                 expect(iterationStartStub.callCount).to.eql(2);
                 done();
-            } catch(e) {
+            } catch (e) {
                 done(e);
             }
         });
@@ -161,7 +163,7 @@ describe('flavor-downloader tests', function() {
             downloadFile: stub
         };
 
-        var flavorDwonloader = getFlavorDownloader(function(mocks){
+        var flavorDwonloader = getFlavorDownloader(function (mocks) {
             mocks['./utils/http-utils'] = httpUtilsMock;
         });
 
@@ -176,7 +178,7 @@ describe('flavor-downloader tests', function() {
             try {
                 expect(iterationStartStub.callCount).to.eql(2);
                 done();
-            } catch(e) {
+            } catch (e) {
                 done(e);
             }
         });

--- a/tests/flavor-downloader-spec.js
+++ b/tests/flavor-downloader-spec.js
@@ -81,7 +81,7 @@ describe('flavor-downloader tests', function() {
         return flavorDownloader;
     }
 
-    it.skip('should download all files successfully', function (done) {
+    it('should download all files successfully', function (done) {
         var flavorDownloader = getFlavorDownloader();
         flavorDownloader.on("iteration-end", function() {
             try {
@@ -95,7 +95,7 @@ describe('flavor-downloader tests', function() {
         flavorDownloader.start();
     });
 
-    it.skip('should try to download failed ts again', function (done) {
+    it('should try to download failed ts again', function (done) {
         var listOfFiles = ['media-uefvqmelj_b1017600_11.ts', 'media-uefvqmelj_b1017600_12.ts', 'media-uefvqmelj_b1017600_13.ts', 'media-uefvqmelj_b1017600_15.ts'];
         var flavorDwonloader = getFlavorDownloader(function (mocks) {
             mocks['q-io/fs'] = generateQioMock(listOfFiles);
@@ -112,7 +112,7 @@ describe('flavor-downloader tests', function() {
         });
     });
 
-    it.skip('should shutdown downloader after 1 iteration', function (done) {
+    it('should shutdown downloader after 1 iteration', function (done) {
         var flavorDownloader = getFlavorDownloader();
         flavorDownloader.start();
         var iterationEndStub = sinon.stub();


### PR DESCRIPTION
… manifest name

* Update flavor-downloader stop/start to have a consistent, promise-based, API
* Propagate errors