### PR TITLE
0.13.0 PLAT 5120

### DIFF
--- a/common/config/config.json.template
+++ b/common/config/config.json.template
@@ -33,15 +33,16 @@
     "applicationName" : "kLive",
     "port" : 1935,
     "user" : "",
-    "password" : "",
-    "maxPlaylistFileAgeMillisec" : 300000
+    "password" : ""
+
   },
   "webServerParams" : {
     "applicationName" : "kLive",
     "port" : 8080,
     "logLevel" : "DEBUG",
     "logFileName" : "~/dvr/kDvrWebServer.log",
-    "logToConsole" : true
+    "logToConsole" : true,
+    "chunklistExpireAge" : 300000
   },
   "backendClient" : {
     "adminSecret" :"admin secret",

--- a/common/config/config.json.template
+++ b/common/config/config.json.template
@@ -33,7 +33,8 @@
     "applicationName" : "kLive",
     "port" : 1935,
     "user" : "",
-    "password" : ""
+    "password" : "",
+    "maxPlaylistFileAgeMillisec" : 300000
   },
   "webServerParams" : {
     "applicationName" : "kLive",

--- a/dvr-ws/routes/index.js
+++ b/dvr-ws/routes/index.js
@@ -2,18 +2,26 @@ var express = require('express');
 var router = express.Router();
 var config = require('../../common/Configuration');
 var logger = require('../logger/logger');
-var qio = require('q-io/fs');
 var path = require('path')
 var persistenceFormat = require('../../common/PersistenceFormat');
 
 router.get(/\/smil\:([^\\/]*)_all\.smil\/([^\?]*)/i, function(req, res) {
-
+    var that = this;
     var entryId = req.params[0];
     var fileName = req.params[1];
 
-    var disk = path.join(persistenceFormat.getEntryFullPath(entryId),fileName);
-    res.sendFile(disk);
-
+    var fullpath = path.join(persistenceFormat.getEntryFullPath(entryId),fileName);
+    res.sendFile(fullpath);
+/*
+    checkFileModifiedTime(fullpath)
+        .then( function() {
+            res.sendFile(fullpath);
+        })
+        .catch( function() {
+            res.status(404).send('%s not found', that.filename);
+        });
+*/
 });
+
 
 module.exports = router;

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -227,7 +227,7 @@ module.exports = (function(){
                 var relevantEntries = _.filter(liveEntries, function (e) {
                     return e.entryId.indexOf(that.prefix) === 0;
                 });
-                logger.debug("Entries received from Wowza: %j", relevantEntries);
+                logger.debug("Received playing entries list from Wowza: %j", relevantEntries);
                 return relevantEntries;
             })
             .then(function(liveEntries){

--- a/lib/entry/FlavorDownloader.js
+++ b/lib/entry/FlavorDownloader.js
@@ -16,6 +16,7 @@ var config = require('../../common/Configuration');
 var glob = require('glob');
 var httpUtils=require('../utils/http-utils');
 var ErrorUtils = require('./../utils/error-utils');
+var fsUtils = require('./../utils/fs-utils');
 
 function isSameM3U8(a, b) {
     if (a.length !== b.length) {
@@ -41,9 +42,10 @@ var FlavorDownloader = (function() {
         this.id = this.constructor.uniqueId;
         this.constructor.uniqueId = this.constructor.uniqueId + 1;
         this.entryId = entryObj.entryId;
-        this.flavor = flavorObj.name ;
+        this.flavor = flavorObj.name;
         this.streamUrl = flavorObj.liveURL;
         this.destFolderPath = destPath;
+        this.newPlaylistName = newPlaylistName;
         this.shouldRun = true;
         this.runStatus = 'uninitialized';
         this.successPollingInterval = config.get('flavorSuccessPollingInterval');
@@ -51,20 +53,20 @@ var FlavorDownloader = (function() {
         this.tmpM3u8Folder = path.join(destPath, 'tmpM3u8');
         this.downloadedChunks = {};
         this.chunksToDownload = {};
-        this.loggerInformation =  "[" + that.entryId + "][" + that.flavor + "][id:" + that.id + "] ";
-        this.logger =  loggerModule.getLogger("FlavorDownloader",  this.loggerInformation);
+        this.loggerInformation = "[" + that.entryId + "][" + that.flavor + "][id:" + that.id + "] ";
+        this.logger = loggerModule.getLogger("FlavorDownloader", this.loggerInformation);
 
         var lastM3U8Content = null;
         this._lastM3U8Time = 0;
 
         this.tsHttpUtils = httpUtils.HttpDownloader(this.logger);
-        this.m3u8HttpUtils = httpUtils.HttpDownloader(this.logger, function(newM3u8Content) {
-            var retValue=false;
+        this.m3u8HttpUtils = httpUtils.HttpDownloader(this.logger, function (newM3u8Content) {
+            var retValue = false;
             //optimization: if M3U8 has not updated the last 10 seconds then ignore
             if (lastM3U8Content &&
                 new Date() - that._lastM3U8Time < 10000 &&
                 isSameM3U8(lastM3U8Content, newM3u8Content)) {
-                    retValue = true;
+                retValue = true;
             }
             lastM3U8Content = newM3u8Content;
             return retValue;
@@ -80,7 +82,8 @@ var FlavorDownloader = (function() {
     }
     util.inherits(FlavorDownloader, events.EventEmitter);
 
-    var downloadIndefinitely = function(onIterationEndCallback) {
+    var downloadIndefinitely;
+    downloadIndefinitely = function (onIterationEndCallback) {
         var that = this;
         var iterationFailed = false;
         if (!that.shouldRun) {
@@ -99,16 +102,16 @@ var FlavorDownloader = (function() {
                     that.logger.error("Flavor downloader failed to initialize");
                 }
             })
-            .then(function() {
+            .then(function () {
                 if (that.shouldRun) {
                     var interval = iterationFailed ? that.failPollingInterval : that.successPollingInterval;
-                    that.logger.debug("scheduling downloadIndefinitely to run in %s seconds", interval/1000);
+                    that.logger.debug("scheduling downloadIndefinitely to run in %s seconds", interval / 1000);
                     setTimeout(function () {
                         downloadIndefinitely.call(that, onIterationEndCallback);
                     }, interval);
                 }
             })
-            .finally(function() {
+            .finally(function () {
                 that.emit("iteration-end");
                 if (!that.shouldRun) {
                     downloaderEnd.resolve();
@@ -153,10 +156,11 @@ var FlavorDownloader = (function() {
             baseUrl = parsedUrl.href.substring(0, parsedUrl.href.lastIndexOf('/'));
             playlistName = path.basename(parsedUrl.pathname);
             var playlistDestPath = path.join(that.tmpM3u8Folder, playlistName);
-            return that.m3u8HttpUtils.downloadFile(that.streamUrl, playlistDestPath).then(function(content) {
-                that._lastM3U8Time = new Date();
-                return { path: playlistDestPath, content: content };
-            });
+            return that.m3u8HttpUtils.downloadFile(that.streamUrl, playlistDestPath)
+                .then(function(content) {
+                    that._lastM3U8Time = new Date();
+                    return { path: playlistDestPath, content: content };
+                });
         };
         var updateListOfNewChunksToProcess = function(downloadedM3u8) {
             var newChunks = _.chain(downloadedM3u8.items.PlaylistItem)
@@ -312,10 +316,19 @@ var FlavorDownloader = (function() {
         var that = this;
         that.logger.debug("Stopping flavor downloader");
         that.shouldRun = false;
+        var fullPath = that.destFolderPath + '/' + that.newPlaylistName;
+        var fileModifiedTime = new Date();
+        fileModifiedTime.setTime(Date.now() - 86400000);
+
         return downloaderEnd.promise
             .then(function() {
                 that.logger.info("FlavorDownloader Stopped");
                 delete FlavorDownloader.activeInstances[that.id];
+
+                // invalidate chunklist by changing chunklist modified time to 1 day back
+                that.logger.debug('changing %s modified time to %s', fullPath, fileModifiedTime.toDateString());
+                fsUtils.updateFileModifiedTime(fullPath, fileModifiedTime);
+
                 that.runStatus = 'stopped';
                 that.emit('stopped', that.flavor);
 

--- a/lib/utils/fs-utils.js
+++ b/lib/utils/fs-utils.js
@@ -10,6 +10,8 @@ var Q = require('q');
 var t = require('tmp');
 var path = require('path');
 var mkdirp = require('mkdirp');
+var fs = require('fs');
+var errorUtils = require('./../utils/error-utils');
 
 module.exports = (function(){
 
@@ -48,10 +50,64 @@ module.exports = (function(){
             });
     }
 
+    function updateFileModifiedTime(fullPath, fileModifiedTime) {
+
+        var that = this;
+        var res = true;
+
+        try {
+            fs.utimes(fullPath, fileModifiedTime, fileModifiedTime, function (err) {
+                logger.error('error: %s, failed to update modified time of %s to %s', err, that.fullPath, that.fileModifiedTime.toDateString());
+                res = false;
+            });
+
+        } catch (e) {
+            e = (e === undefined) ? new Error('suspecting undifined arg') : e;
+            logger.error('exception, failed to set modified time of %s to %s. error: %s', fullPath, fileModifiedTime.toDateString(), errorUtils.error2string(e));
+        }
+        finally {
+            if (res) {
+                logger.warn('successfully updated modified time of %s to %s', fullPath, fileModifiedTime.toDateString());
+            }
+        }
+
+    }
+
+    function checkFileModifiedTime(fullPath, maxAllowedFileAgeMillisec) {
+
+        return Q.Promise(function(resolve, reject) {
+
+            maxAllowedFileAgeMillisec = (maxAllowedFileAgeMillisec !== undefined) ? maxAllowedFileAgeMillisec : config.mediaServer.maxPlaylistFileAgeMillisec;
+            var oldestValidModifiedTime = Date.now() - maxAllowedFileAgeMillisec;
+
+            try {
+                    fs.stat(fullPath, function (err, stats) {
+
+                    if (stats.mtime.getTime() > oldestValidModifiedTime)
+                        resolved();
+                    else {
+                        logger.warn('modified time of %s is %s. File is too old to use.', fullPath, fileModifiedTime.toDateString());
+                        reject();
+                    }
+
+                });
+
+            } catch (e) {
+                e = (e === undefined) ? new Error('internal error while trying to read file') : e;
+                logger.error('exception, failed to get modified time of %s. error: %s', fullPath, errorUtils.error2string(e));
+
+                reject();
+            }
+
+        });
+    }
+
     return {
         writeFileAtomically : writeFileAtomically,
         cleanFolder : cleanFolder,
-        existsAndNonZero : existsAndNonZero
+        existsAndNonZero : existsAndNonZero,
+        updateFileModifiedTime : updateFileModifiedTime,
+        checkFileModifiedTime : checkFileModifiedTime
     };
 
 })();

--- a/lib/utils/fs-utils.js
+++ b/lib/utils/fs-utils.js
@@ -73,20 +73,21 @@ module.exports = (function(){
 
     }
 
-    function checkFileModifiedTime(fullPath, maxAllowedFileAgeMillisec) {
+    function checkIsFileExpired(fullPath, fileExpireAge) {
+
+        var that = this;
 
         return Q.Promise(function(resolve, reject) {
 
-            maxAllowedFileAgeMillisec = (maxAllowedFileAgeMillisec !== undefined) ? maxAllowedFileAgeMillisec : config.mediaServer.maxPlaylistFileAgeMillisec;
-            var oldestValidModifiedTime = Date.now() - maxAllowedFileAgeMillisec;
+            var oldestValidAge = Date.now() - fileExpireAge;
 
             try {
                     fs.stat(fullPath, function (err, stats) {
 
-                    if (stats.mtime.getTime() > oldestValidModifiedTime)
-                        resolved();
+                    if (stats.mtime.getTime() > oldestValidAge)
+                        resolve();
                     else {
-                        logger.warn('modified time of %s is %s. File is too old to use.', fullPath, fileModifiedTime.toDateString());
+                        logger.warn('modified time of %s is %s. File expired.', that.fullPath, stats.mtime.toDateString());
                         reject();
                     }
 
@@ -94,7 +95,7 @@ module.exports = (function(){
 
             } catch (e) {
                 e = (e === undefined) ? new Error('internal error while trying to read file') : e;
-                logger.error('exception, failed to get modified time of %s. error: %s', fullPath, errorUtils.error2string(e));
+                logger.error('exception, failed to get modified time of %s. error: %s', that.fullPath, errorUtils.error2string(e));
 
                 reject();
             }
@@ -107,7 +108,7 @@ module.exports = (function(){
         cleanFolder : cleanFolder,
         existsAndNonZero : existsAndNonZero,
         updateFileModifiedTime : updateFileModifiedTime,
-        checkFileModifiedTime : checkFileModifiedTime
+        checkIsFileExpired : checkIsFileExpired
     };
 
 })();


### PR DESCRIPTION
Changes include Live and Web server side support for 404 reply, in case chunklist has expired.
Chunklist file is defined as expired if its age is older than configurable value.
Trigger to invalidate chunklist file is by the state machine of the EntryId, changing state to stopped. In that case, the chunklist files of all entry’s flavours are invalidated.
Still in progress, adding ENDLIST tag when no DC (media server) is available for the EntryId.