### PR TITLE
-1.0-PLAT-PLAT-5976-r

### DIFF
--- a/lib/playlistGenerator/ConcatSource.js
+++ b/lib/playlistGenerator/ConcatSource.js
@@ -285,11 +285,15 @@ ConcatSource.prototype.split = function (newSrc,r) {
         } else {
             that.durationsMan.setDurationAt(lastThisIndex-1,updatedDuration);
         }
-
-        that.logger.debug("split %j-%j len=%j",lastThisIndex,firstThatIndex,that.durationsMan.firstDTS.length);
     }
 
+    that.logger.debug("split %j-%j len=%j",lastThisIndex,firstThatIndex,that.durationsMan.firstDTS.length);
+
     _.each(that.inner.durations.slice(lastThisIndex,firstThatIndex),function(duration){
+        var item = that.getItem(lastThisIndex);
+        that.logger.info('split: gap. delete chunk = [%s]; Dts = [%d]; Duration = [%d]',
+            item.paths, item.firstDTS, item.durations);
+
         removeItem.call(that,lastThisIndex);
         that.inner.lastEncoderDTS -= duration;
         firstThatIndex--;
@@ -311,7 +315,7 @@ ConcatSource.prototype.split = function (newSrc,r) {
             newSrc.keyFrameDurations.push(item.keyFrames);
         }
 
-        that.logger.info('split: Append clip = [%s]; Dts = [%d]; Duration = [%d]',
+        that.logger.info('split: Append chunk = [%s]; Dts = [%d]; Duration = [%d]',
             item.paths, item.firstDTS, item.durations);
 
     });

--- a/lib/playlistGenerator/MixFilterClip.js
+++ b/lib/playlistGenerator/MixFilterClip.js
@@ -235,6 +235,8 @@ MixFilterClip.prototype.insert = function (fileInfo) {
         checkNewSource.call(this,'a',fileInfo);
     }
 
+    that.logger.debug('insert %j',fileInfo);
+
     for( var idx = 0; idx < that.inner.sources.length; idx++ ) {
         var src = that.inner.sources[idx];
 
@@ -252,7 +254,7 @@ MixFilterClip.prototype.insert = function (fileInfo) {
                 break;
         }
 
-        that.logger.debug('Insert Clip %s: Track=%s; Duration=%d First_dts=%d Enc_dts=%d wrap=%j',
+        that.logger.trace('insert %s: Track=%s; Duration=%d First_dts=%d Enc_dts=%d wrap=%j',
             fileInfo.path, src.inner.tracks,
             track.duration.toFixed(2),
             track.firstDTS,
@@ -286,9 +288,14 @@ MixFilterClip.prototype.getDTSRange = function(){
         filteredSrc = that.inner.sources;
     }
 
-    _.each(filteredSrc,function(s) {
+    _.every(filteredSrc,function(s) {
         var range = s.getDTSRange();
-        retVal.mergeWith(range);
+        if(range.valid) {
+            retVal.mergeWith(range);
+        } else {
+            retVal = range;
+        }
+        return retVal.valid;
     });
 
     //that.logger.debug('getDTSRange. %j', retVal);

--- a/lib/playlistGenerator/Playlist.js
+++ b/lib/playlistGenerator/Playlist.js
@@ -218,7 +218,7 @@ Playlist.prototype.doValidate = function playlist_doValidate(opts) {
 
     if(_.some(that.inner.clipTimes, function(clipTime,index){
             if( index > 0 ){
-                return that.inner.clipTimes[index-1] + that.inner.durations[index-1] > that.inner.clipTimes[index];
+                return that.inner.clipTimes[index] > 0 && that.inner.clipTimes[index-1] + that.inner.durations[index-1] > that.inner.clipTimes[index];
             }
             return false;
         })) {
@@ -348,11 +348,6 @@ var calcClipStartTimeAndDuration = function(index){
 
         if( that.inner.clipTimes[index].value != retVal.min) {
             that.inner.clipTimes[index].value = retVal.min;
-            that.logger.info("Recalculate Offsets And Duration(%d). Set clipTime: %s (%d). duration: %d",
-                index,
-                new Date(that.inner.clipTimes[index]),
-                that.inner.clipTimes[index],
-                that.inner.durations[index]);
 
             // special case for first clip
             if (index === 0) {
@@ -361,6 +356,13 @@ var calcClipStartTimeAndDuration = function(index){
             }
         }
     }
+
+    that.logger.info("Recalculate Offsets And Duration(%d). Set clipTime: %s (%d). duration: %d",
+        index,
+        new Date(that.inner.clipTimes[index]),
+        that.inner.clipTimes[index],
+        that.inner.durations[index]);
+
     return retVal;
 };
 
@@ -538,7 +540,7 @@ Playlist.prototype.toJSON = function() {
 
     // durations can have 0 values during transition period
     // when some sequences have emptied their clip[0] while others not.
-    if(obj.durations.length && obj.durations[0] <= 0) {
+    if(obj.durations.length > 0) {
        obj.durations = _.filter(obj.durations, function (d, index) {
             return d > 0;
         });

--- a/lib/playlistGenerator/PlaylistGenerator.js
+++ b/lib/playlistGenerator/PlaylistGenerator.js
@@ -474,6 +474,10 @@ PlaylistGenerator.prototype.doValidate = function() {
     return this.playlistImp.doValidate();
 };
 
+PlaylistGenerator.prototype.validate = function() {
+    return this.playlistImp.validate();
+};
+
 PlaylistGenerator.prototype.checkFileExists = function(fileName){
     return this.playlistImp.checkFileExists(fileName);
 };


### PR DESCRIPTION
- when producing playlist.json filter out all 0 duration clips created due to quicks encoder restarts.
- set clip duration to 0 if any of sources contributing to it is empty.