### PR TITLE
Plat 5838 live consistency tests

### DIFF
--- a/common/config/config.json.template
+++ b/common/config/config.json.template
@@ -51,8 +51,8 @@
   },
   "preserveOriginalHLS": {
       "enable": false,
-      "createFolderPerSession": true,
-      "runDurationInMinutes": 5
+      "createFolderPerSession": true
+
   },
   "diagnostics": {
       "minChunkDurationInSec": 1,

--- a/lib/Adapters/AdapterFactory.js
+++ b/lib/Adapters/AdapterFactory.js
@@ -1,9 +1,8 @@
 
+var config = require('../../common/Configuration');
 var WowzaAdapter=require('./WowzaAdapter.js');
 var CompositeWowzaAdapter=require('./CompositeWowzaAdapter.js');
 var APIQueryAdapter=require('./APIQueryAdapter.js');
-var TestAdapter=require('./TestAdapter.js');
-
 var config = require('../../common/Configuration');
 const _ = require('underscore');
 
@@ -11,21 +10,27 @@ var simulateStreams = config.get('simulateStreams');
 var regressionAdapterConfig = config.get('regressionAdapter');
 
 var mediaServerConfig = config.get('mediaServer');
+var adapter;
 
 exports.getAdapter = function() {
 
     if (regressionAdapterConfig && regressionAdapterConfig.enable) {
-        let RegressionAdapter=require('./RegressionAdapter/RegressionAdapter');
-        return new RegressionAdapter();
-    }
-    if (simulateStreams && simulateStreams.enable) {
-        return require('./TestAdapter.js').TestAdapter.instance;
+        if (!adapter) {
+            let RegressionAdapter = require('./RegressionAdapter/RegressionAdapter');
+            adapter = new RegressionAdapter();
+        }
+    } else if (simulateStreams && simulateStreams.enable) {
+        if (!adapter) {
+            let RegressionAdapter = require('./RegressionAdapter/RegressionAdapter');
+            adapter = require('./TestAdapter.js').TestAdapter.instance;
+        }
     } else {
         if (_.isArray(mediaServerConfig.hostname)) {
-            return new CompositeWowzaAdapter(mediaServerConfig);
+            adapter = new CompositeWowzaAdapter(mediaServerConfig);
         } else {
-            return new WowzaAdapter(mediaServerConfig,mediaServerConfig.hostname);
+            adapter = new WowzaAdapter(mediaServerConfig,mediaServerConfig.hostname);
         }
     }
 
+    return adapter;
 };

--- a/lib/Adapters/RegressionAdapter/RegressionAdapter.js
+++ b/lib/Adapters/RegressionAdapter/RegressionAdapter.js
@@ -1,4 +1,4 @@
-var configManinpulator = require('./RegressionConfig.js').RegressionConfig.instance;
+var configManinpulator = require('./RegressionConfig.js').getConfig();
 var Q = require('q');
 var _ = require('underscore');
 var fs=require('fs');

--- a/lib/Adapters/TestAdapter.js
+++ b/lib/Adapters/TestAdapter.js
@@ -9,11 +9,13 @@ var m3u8Parser = require('./../manifest/promise-m3u8');
 var networkClient = require('./../NetworkClientFactory').getNetworkClient();
 var url=require('url');
 var logger =  require('../../common/logger').getLogger("TestAdapter");
+const fs = require('fs');
 
-const simulateStreams = config.get('simulateStreams');
+var simulateStreams = config.get('simulateStreams');
 const preserveOriginalHLS = config.get('preserveOriginalHLS');
-const overrideOldRecordedHLS = config.get('overrideOldRecordedHLS');
+const createFolderPerSession = preserveOriginalHLS.createFolderPerSession;
 const runDurationInMinutes = preserveOriginalHLS.runDurationInMinutes;
+
 
 var singletonInstance = Symbol();
 var singletonEnforcer = Symbol();
@@ -25,6 +27,8 @@ class TestAdapter extends BaseTestAdapter {
          if (enforcer !== singletonEnforcer) {
              throw "Cannot construct singleton";
          }
+
+         this.setRecordingPathExtension();
 
          if (preserveOriginalHLS.enable) {
              this.setRunEndTimer();
@@ -111,11 +115,12 @@ TestAdapter.prototype.getLiveEntries=function() {
 
             return m3u8Parser.parseM3U8(content.body, {'verbatim': true}).then(function (m3u8) {
 
-
                 var result = [];
+
+                // this loop is
                 for (let i = 0; i < simulateStreams.count; i++) {
 
-                    let extension = overrideOldRecordedHLS === true || (!simulateStreams.firstIndex) ? 1: simulateStreams.firstIndex;
+                    let extension = createFolderPerSession && simulateStreams.firstIndex ? simulateStreams.firstIndex : 1;
                     let path = simulateStreams.path ? util.format('%s-%d',simulateStreams.path, extension)  : util.format(simulateStreams.entryId,i+1);
 
                     var flavors={};
@@ -145,6 +150,43 @@ TestAdapter.prototype.getLiveEntries=function() {
 
         });
 
+
+}
+
+TestAdapter.prototype.setRecordingPathExtension = function() {
+
+    // if override = true the index that will be overwritten is the lowest (most likely can).
+    if (!createFolderPerSession) {
+        return;
+    }
+
+    let recordingFullPath = config.get('rootFolderPath') + '/';
+    // recordingFullPath = recordingFullPath.replace(/\//g,'\\\/');
+    // recordingFullPath = recordingFullPath.replace(/\./g,'\\\.');
+    let relativePath = simulateStreams.path ? simulateStreams.path :  simulateStreams.entryId;
+    let index = 1;
+    let checkPath = util.format('%s%s-%d', recordingFullPath, relativePath, index );
+    // let pattern = util.format('%s(%s\\s\\d+)', recordingFullPath, relativePath);
+
+    try {
+        // use loop to find highest index
+        let stat = fs.lstatSync(checkPath);
+
+        while (stat.isDirectory()) {
+            index++;
+            checkPath = util.format('%s%s-%s', recordingFullPath, relativePath, index);
+            stat = fs.lstatSync(checkPath);
+        }
+    } catch(err) {
+        if (err.code != 'ENOENT') {
+            logger.debug('new recording path, %s', recordingFullPath);
+            throw err;
+        }
+    }
+    finally
+    {
+        this.entryOb = index;
+    }
 
 }
 

--- a/lib/Adapters/TestAdapter.js
+++ b/lib/Adapters/TestAdapter.js
@@ -45,16 +45,18 @@ class TestAdapter extends BaseTestAdapter {
 
 TestAdapter.prototype.setRunEndTimer = function() {
 
-    var durationMillisec = 60000 * runDurationInMinutes;
-    var that = this;
+    if(runDurationInMinutes) {
 
-    setTimeout((function(duration) {
-        return () =>
-        {
-            logger.info('recording ended (duration: %s minutes). LiveController will exit gracefully.', duration/60000);
-            that.gracefullyExit(0);
-        }
-    })(durationMillisec), durationMillisec);
+        var durationMillisec = 60000 * runDurationInMinutes;
+        var that = this;
+
+        setTimeout((function (duration) {
+            return () => {
+                logger.info('recording ended (duration: %s minutes). LiveController will exit gracefully.', duration / 60000);
+                that.gracefullyExit(0);
+            }
+        })(durationMillisec), durationMillisec);
+    }
 
 }
 


### PR DESCRIPTION
1) Fixed issues that prevented from regression and hls preservation to run properly after merge to 1.0
2) runDurationInMinutes can be undefined, in that case preservation
will continue forever and liveController process won’t stop
automatically.
3) config param runDurationInMinutes (under preserveOriginalHLS) was
removed from config.json.template. In order to limit the time a stream
is preserved (for data warehouse preservation), need to add it
configMapping.json