### PR TITLE
preserve hls exactly as entry stream is saved in production

### DIFF
--- a/common/PersistenceFormat.js
+++ b/common/PersistenceFormat.js
@@ -9,7 +9,6 @@ var _ = require('underscore');
 var Q = require('q');
 
 const tsChunktMatch =  new RegExp(/media-([^_]+).*?([\d]+)\.ts.*/);
-var preserveOriginalHLS = config.get('preserveOriginalHLS').enable;
 const rootFolder = config.get('rootFolderPath');
 
 class PersistenceFormatBase {
@@ -64,12 +63,6 @@ class PersistenceFormatBase {
     getEntryHash (entryId) {
         return entryId.charAt(entryId.length - 1);
     }
-}
-
-
-
-if(!preserveOriginalHLS) {
-    class DefaultPersistenceFormat extends PersistenceFormatBase {
 
         getBasePathFromFull(fullPath) {
             // cut away both flavor and time components
@@ -92,21 +85,14 @@ if(!preserveOriginalHLS) {
             return tsChunkName;
         }
 
+    compressTsChunkName(tsChunkName) {
+        var matched = tsChunktMatch.exec(tsChunkName);
+        if (matched) {
+            return matched[1] + '-' + matched[2] + '.ts';
+        }
+        return tsChunkName;
     }
-    module.exports = new DefaultPersistenceFormat();
-} else {
-    class PreserveOriginalHLSFormat extends PersistenceFormatBase {
-        getBasePathFromFull(fullPath) {
-            return fullPath.substring(0,_.lastIndexOf(fullPath,path.sep)+1);
-        }
 
-        getFlavorPath (destPath,param) {
-            return { fullPath:destPath, hash:param };
-        }
-
-        compressChunkName(tsChunkName) {
-            return super.getMP4FileNamefromInfo(tsChunkName);
-        }
-    }
-    module.exports = new PreserveOriginalHLSFormat();
 }
+
+module.exports = new PersistenceFormatBase();

--- a/common/PersistenceFormat.js
+++ b/common/PersistenceFormat.js
@@ -11,7 +11,7 @@ var Q = require('q');
 const tsChunktMatch =  new RegExp(/media-([^_]+).*?([\d]+)\.ts.*/);
 const rootFolder = config.get('rootFolderPath');
 
-class PersistenceFormatBase {
+class PersistenceFormat {
     getEntryBasePath (entryId) {
         return path.join(rootFolder, this.getEntryHash(entryId), entryId);
     }
@@ -95,4 +95,4 @@ class PersistenceFormatBase {
 
 }
 
-module.exports = new PersistenceFormatBase();
+module.exports = new PersistenceFormat();

--- a/lib/Adapters/RegressionAdapter/RegressionConfig.js
+++ b/lib/Adapters/RegressionAdapter/RegressionConfig.js
@@ -13,6 +13,7 @@ const path = require("path");
 const util = require("util");
 var glob = require('glob');
 const _utility = require('./regression_utility');
+const persistenceFormat = require('../../../common/PersistenceFormat');
 
 
 var singletonInstance = Symbol();
@@ -230,7 +231,7 @@ RegressionConfig.prototype.initChunklistEdgeIndexes = function (entry_index) {
     var entryId = entryConfig.entryId;
     var path_fix = entryConfig.entryPath.replace('%20', ' ');
     let flavors = entryConfig.flavorParamsIds.split(',').map((item) => item.trim());
-    var fullPath = this.regressionConfig.dataWarehouseRootFolderPath + '/' + path_fix + '/' + flavors[0];
+    var fullPath = path.join(persistenceFormat.getEntryBasePath(path_fix), flavors[0]);
     let first_index_initialized = !isNaN(entryConfig.start_chunklist_index) && !(parseInt(entryConfig.start_chunklist_index) === -1);
     let last_index_initialized = !isNaN(entryConfig.last_chunklist_index) && !(parseInt(entryConfig.last_chunklist_index) === -1);
     let chunklist_indexes_not_initialized = !first_index_initialized || !last_index_initialized;
@@ -413,7 +414,7 @@ RegressionConfig.prototype.updateRegressionConfig = function(cl_config, entry_in
             // todo: when multiple entries are supported use real entry_index
             entry_index = 0;
 
-            if (!cl_config['flavors']) {
+         /*   if (!cl_config['flavors']) {
                 cl_config['flavors'] = '1,2,3,4';
             }
 
@@ -428,13 +429,15 @@ RegressionConfig.prototype.updateRegressionConfig = function(cl_config, entry_in
                     "override": results_db_override,
                     "history_count": 0
                 }
-            };
+            };*/
 
         } else {
             if (cl_config.hasOwnProperty('flavors')) {
                 this.regressionConfig.entries[entry_index].flavorParamsIds = cl_config['flavors'];
             }
-            this.regressionConfig.entries[entry_index].entryId = cl_config['entry_id'];
+            if (cl_config['entry_id']) {
+                this.regressionConfig.entries[entry_index].entryId = cl_config['entry_id'];
+            }
             if (cl_config.hasOwnProperty('override')) {
                 this.regressionConfig.entries[entry_index].validator['override'] = results_db_override;
             }

--- a/lib/Adapters/RegressionAdapter/RegressionEngine.js
+++ b/lib/Adapters/RegressionAdapter/RegressionEngine.js
@@ -28,7 +28,6 @@ var mediaServer = config.get('mediaServer');
 var entriesInfo = config.get('regressionAdapter').entries;
 
 
-
 let logheader1 = function(literals, ...values) {
 
     return '[' + values[0] + '-' + values[1] + '] <<<< ' + values[2] + ' >>>> ';
@@ -147,7 +146,7 @@ RegressionEngine.prototype.initEntries = function() {
                 _.each(that.entries[entryConfig.entryId].flavors, function (flavor) {
                     that.entries[entryConfig.entryId].chunklist_index[flavor] = that.entries[entryConfig.entryId].initial_chunklist_index - 1;
                     that.entries[entryConfig.entryId].validation_failure_tolerated_count[flavor] = 0;
-                    that.entries[entryConfig.entryId].fullpath[flavor] = that.rootFolderPath + '/' + entryConfig.entryPath + '/' + flavor;
+                    that.entries[entryConfig.entryId].fullpath[flavor] = persistenceFormat.getFlavorFullPath(entryConfig.entryPath, flavor);
                     that.entries[entryConfig.entryId].playlist_sent[flavor] = 0;
                     that.entries[entryConfig.entryId].promise_per_flavor[flavor] = Q.defer();
                     that.entries[entryConfig.entryId].chunklist_map[flavor] = {};

--- a/lib/Adapters/TestAdapter.js
+++ b/lib/Adapters/TestAdapter.js
@@ -123,7 +123,7 @@ TestAdapter.prototype.getLiveEntries=function() {
                 for (let i = 0; i < simulateStreams.count; i++) {
 
                     let extension = createFolderPerSession && simulateStreams.firstIndex ? simulateStreams.firstIndex : 1;
-                    let path = simulateStreams.path ? util.format('%s-%d',simulateStreams.path, extension)  : util.format(simulateStreams.entryId,i+1);
+                    let path = simulateStreams.path ? util.format('%s-%d',simulateStreams.path, extension)  : util.format('%s-%d', simulateStreams.entryId,i+1);
 
                     var flavors={};
                     _.each(m3u8.items.StreamItem,function(streamItem,i) {


### PR DESCRIPTION
After this commit every preservation shall override previous unless
either copied/renamed or suing SimulateStreams + path parameter (with
unique value).