### PR TITLE
Should not explicitly call python2.7

### DIFF
--- a/liveRecorder/ZombieEntryCatchers.py
+++ b/liveRecorder/ZombieEntryCatchers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import time
 import logging.handlers
 import os

--- a/liveRecorder/install.sh
+++ b/liveRecorder/install.sh
@@ -11,17 +11,17 @@ HOSTNAME=$(hostname)
 HOSTNAME_DIRECTORY="$HOME_DIRECTORY/$HOSTNAME"
 echo "home directory $HOME_DIRECTORY"
 if [ ! -d $HOME_DIRECTORY ]; then
-echo "ERROR: can't find recording path"
-exit
+    echo "ERROR: can't find recording path"
+    exit 1
 fi
-if ! [[ $(python2.7 --version 2>&1) == *2\.7\.* ]]; then
-echo "Requrie python version 2.7.x";
-exit
+if ! [[ $(python --version 2>&1) == *2\.7\.* ]]; then
+    echo "Python version >= 2.7.0 is required";
+    exit 2
 fi
-pip2.7 install  poster
-pip2.7 install psutil
-pip2.7 install m3u8
-pip2.7 install schedule
+pip install  poster
+pip install psutil
+pip install m3u8
+pip install schedule
 easy_install pycrypto
 mkdir -p $HOME_DIRECTORY
 mkdir -p "$HOME_DIRECTORY/recordings"

--- a/liveRecorder/install.sh
+++ b/liveRecorder/install.sh
@@ -22,7 +22,7 @@ pip install  poster
 pip install psutil
 pip install m3u8
 pip install schedule
-easy_install pycrypto
+pip install pycrypto
 mkdir -p $HOME_DIRECTORY
 mkdir -p "$HOME_DIRECTORY/recordings"
 mkdir -p "$HOME_DIRECTORY/recordings/newSession"

--- a/liveRecorder/serviceWrappers/linux/liveRecorder
+++ b/liveRecorder/serviceWrappers/linux/liveRecorder
@@ -45,7 +45,7 @@ createFolders() {
 		[ -L ${SHARED_APP_DIR}/${HOSTNAME}/ConcatenationTask/incoming ] || ln -s ${SHARED_APP_DIR}/incoming ${SHARED_APP_DIR}/${HOSTNAME}/ConcatenationTask/incoming
 	else
 		echo "can't find ${SHARED_APP_DIR}, cannot start, check mounts"
-		exit 1
+		exit 2 
 	fi
 }
 
@@ -53,9 +53,9 @@ start() {
      modules=(schedule m3u8 poster psutil pycrypto)
      for module in "${modules[@]}"; do
          python -c "import $module"
-         [ $? -ne 0 ] && pip install $module
+         [ $? -ne 0 ] && echo "Missing $module pip module." && exit 3
     done
-	createFolders || exit 1
+	createFolders || exit 4
     status -p ${PIDFILE}
     if [ $? -eq 0 ]; then
         echo "${NAME} already running"

--- a/liveRecorder/serviceWrappers/linux/liveRecorder
+++ b/liveRecorder/serviceWrappers/linux/liveRecorder
@@ -61,7 +61,7 @@ start() {
         echo "${NAME} already running"
     else
         echo "Starting ${NAME}"
-        python2.7 ${APPLICATION_PATH} >> ${LOGFILE}  2>&1 &
+        python ${APPLICATION_PATH} >> ${LOGFILE}  2>&1 &
         RETVAL=$?
         echo $! > ${PIDFILE}
         if [ ${RETVAL} -eq 0 ]; then


### PR DESCRIPTION
For one thing, just because the minimum version we require is python
2.7, does not mean we won't be able to work with say Python 2.8 or even
Python 3.

The packaging handles dep declarations and ensures the required python
package is deployed and is first in PATH so that invoking ```python```
shall exec the correct version.

When using RHEL/CentOS and the python27 package (which indeed, the
liveRecorder/serviceWrappers/linux/liveRecorder also relies on, see line
26: . /opt/rh/python27/enable):
/opt/rh/python27/root/usr/bin/python
lrwxrwxrwx. 1 root root 7 Jul 11 10:47 /opt/rh/python27/root/usr/bin/python -> python2
lrwxrwxrwx. 1 root root 9 Jul 11 10:47 /opt/rh/python27/root/usr/bin/python2 -> python2.7

so invoking ```python``` shall result in
/opt/rh/python27/root/usr/bin/python2.7 being called.

On Debian/Ubuntu:
Python 2.7.6
python-minimal: /usr/bin/python
/usr/bin/python2.7

So again, same story.