### PR TITLE
Fix alerts beacon handling:

### DIFF
--- a/lib/Diagnostics/DiagnosticsAnalyzer.js
+++ b/lib/Diagnostics/DiagnosticsAnalyzer.js
@@ -95,7 +95,7 @@ class EntryDiagnostics extends EventEmitter{
 
     _checkIncomingBitrate(incomingBitrate, configuredBitrate, input) {
         if (configuredBitrate && incomingBitrate) {
-            let alertObj = new diagnosticsAlerts.BitrateUnmatched(this._entryId, configuredBitrate, incomingBitrate, input);
+            let alertObj = new diagnosticsAlerts.BitrateUnmatched(this._entryId, Math.round(configuredBitrate), Math.round(incomingBitrate), input);
             let percentageDiff = Math.abs((1 - incomingBitrate / configuredBitrate) * 100);
             if (percentageDiff > this._bitrateDiffPercentageAllowed) {
                 this.alertsToSend.push(alertObj);


### PR DESCRIPTION
1) When sending BitrateUnmatched error we want the arguments to be integers instead of fractions