### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "q-io": "1.13.4",
     "request": "^2.61.0",
     "touch": "1.0.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "nan": "2.7.0"
   },
   "description": "DVR implementation built on top of live streams",
   "bugs": {


### PR DESCRIPTION
since "v8-profiler": "5.6.5" was removed, we need to explicitly add nan (2.7.0) to package.json